### PR TITLE
Fixed Avro Phonetic link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/torifat/jsAvroPhonetic.png?branch=master)](https://travis-ci.org/torifat/jsAvroPhonetic)
 
 jsAvroPhonetic is a Javascript implementation of
-[Avro Phonetic](www.omicronlab.com/avro-keyboard.html).
+[Avro Phonetic](http://www.omicronlab.com/avro-keyboard.html).
 
 # License
 


### PR DESCRIPTION
Missing a http:// in the url , so pointing to wrong address. Added http://
